### PR TITLE
feat(nest): NestJS 12 structured logging (`@innei/pretty-logger-nestjs` 1.0.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,13 @@ jobs:
         node-version: [22.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache pnpm modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-pnpm-modules
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,12 @@
 
 ### Features
 
-* **@innei/pretty-logger-nestjs:** NestJS 12 structured logging via ConsoleLogger splitters (`getContextAndMessagesToPrint` / `getContextAndStackAndMessagesToPrint`). Extra plain objects merge into one params object passed as a consola argument. `logLevels` now apply through `isLevelEnabled`.
+* **@innei/pretty-logger-nestjs:** NestJS 12 peer (`@nestjs/common` ^12). Print behavior stays on the 0.4.2 path: PascalCase trailing context, objects as extra message args, unfiltered `debug` / `verbose`.
 
 
 ### Breaking Changes
 
 * **@innei/pretty-logger-nestjs:** peer `@nestjs/common` is `^12` (Nest 10 / 11 dropped).
-* Context is any trailing string, not only PascalCase identifiers.
-* Extra plain objects merge into one params object instead of remaining separate message args.
-* `logLevels` are honored, so previously-unfiltered `debug` / `verbose` may disappear.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+# [1.0.0](https://github.com/Innei/nestjs-pretty-logger/compare/v0.4.2...v1.0.0) (2026-09-01)
+
+
+### Features
+
+* **@innei/pretty-logger-nestjs:** NestJS 12 structured logging via ConsoleLogger splitters (`getContextAndMessagesToPrint` / `getContextAndStackAndMessagesToPrint`). Extra plain objects merge into one params object passed as a consola argument. `logLevels` now apply through `isLevelEnabled`.
+
+
+### Breaking Changes
+
+* **@innei/pretty-logger-nestjs:** peer `@nestjs/common` is `^12` (Nest 10 / 11 dropped).
+* Context is any trailing string, not only PascalCase identifiers.
+* Extra plain objects merge into one params object instead of remaining separate message args.
+* `logLevels` are honored, so previously-unfiltered `debug` / `verbose` may disappear.
+
+
+
 ## [0.4.2](https://github.com/Innei/nestjs-pretty-logger/compare/v0.4.1...v0.4.2) (2026-01-28)
 
 
@@ -84,6 +101,3 @@
 * add reporters ([fb27694](https://github.com/Innei/nestjs-pretty-logger/commit/fb27694d810b9c8ed37e270a02e5454b5bfdd7ff))
 * consola package ([4ca3acd](https://github.com/Innei/nestjs-pretty-logger/commit/4ca3acd3876aae1018c8fc0988bcf5b7da7bb130))
 * init ([1a4626a](https://github.com/Innei/nestjs-pretty-logger/commit/1a4626ae9486088040970d57b72c5d15bd9660ed))
-
-
-

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@innei/bump-version": "1.5.10",
     "@innei/prettier": "0.15.0",
-    "@nestjs/common": "^11.1.1",
+    "@nestjs/common": "^12",
     "@types/node": "22.15.18",
     "eslint": "^9.27.0",
     "eslint-config-hyoban": "4.0.7",

--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -8,12 +8,7 @@ This is the pretty TTY / file path. It does **not** implement Nest `ConsoleLogge
 
 **Peer dependency:** `@nestjs/common` ^12 (NestJS 12 only).
 
-## Breaking changes in 1.0.0
-
-- **Nest 10 / 11 dropped.** Peer is `@nestjs/common` ^12.
-- **Context is any trailing string**, not only PascalCase class names. `logger.log('msg', 'my-context')` now uses `my-context` as the Nest context.
-- **Extra plain objects merge into one params object** and are passed as a single extra consola argument (not a new core `LogObject` field).
-- **`logLevels` are honored.** Previously `debug` / `verbose` always printed; they now follow `isLevelEnabled` (Nest's default levels still include them).
+Print behavior matches 0.4.2: trailing PascalCase strings are Nest context, extra objects stay as message args, and `debug` / `verbose` always print.
 
 ## Installation
 
@@ -50,39 +45,6 @@ async function bootstrap() {
   await app.listen(3000)
 }
 bootstrap()
-```
-
-## Structured params (Nest 12)
-
-Plain objects after the message are treated as structured metadata of the same log entry (Nest's default; `structuredParams` is on unless you set it to `false`):
-
-```typescript
-const logger = new Logger('UserService')
-logger.log('User created', { userId: 1 })
-// context: UserService, params: { userId: 1 } — one consola call
-```
-
-Multiple objects are merged:
-
-```typescript
-logger.log('User created', { userId: 1 }, { email: 'a@b.com' })
-// params: { userId: 1, email: 'a@b.com' }
-```
-
-Opt out with Nest's escape hatch so objects stay as extra message arguments:
-
-```typescript
-const logger = new Logger('UserService', { structuredParams: false })
-logger.log('User created', { userId: 1 })
-```
-
-`logLevels` now actually apply:
-
-```typescript
-const logger = new Logger('UserService', {
-  logLevels: ['error', 'fatal', 'warn'],
-})
-logger.debug('skipped')
 ```
 
 ## Custom logger instance (files, wrapAll, hooks)

--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -4,7 +4,16 @@
 
 Drop-in NestJS `Logger` that prints through [`@innei/pretty-logger-core`](../core/README.md): readable, colorized lines; optional file logging; and hooks for live log streaming.
 
-**Peer dependency:** `@nestjs/common` >= 10.
+This is the pretty TTY / file path. It does **not** implement Nest `ConsoleLogger` `json` or `flattenParams` modes — use Nest's built-in JSON logger if you need machine-readable JSON.
+
+**Peer dependency:** `@nestjs/common` ^12 (NestJS 12 only).
+
+## Breaking changes in 1.0.0
+
+- **Nest 10 / 11 dropped.** Peer is `@nestjs/common` ^12.
+- **Context is any trailing string**, not only PascalCase class names. `logger.log('msg', 'my-context')` now uses `my-context` as the Nest context.
+- **Extra plain objects merge into one params object** and are passed as a single extra consola argument (not a new core `LogObject` field).
+- **`logLevels` are honored.** Previously `debug` / `verbose` always printed; they now follow `isLevelEnabled` (Nest's default levels still include them).
 
 ## Installation
 
@@ -32,6 +41,7 @@ export class AppModule {}
 ```typescript
 import { Logger } from '@innei/pretty-logger-nestjs'
 import { NestFactory } from '@nestjs/core'
+
 import { AppModule } from './app.module'
 
 async function bootstrap() {
@@ -42,14 +52,49 @@ async function bootstrap() {
 bootstrap()
 ```
 
+## Structured params (Nest 12)
+
+Plain objects after the message are treated as structured metadata of the same log entry (Nest's default; `structuredParams` is on unless you set it to `false`):
+
+```typescript
+const logger = new Logger('UserService')
+logger.log('User created', { userId: 1 })
+// context: UserService, params: { userId: 1 } — one consola call
+```
+
+Multiple objects are merged:
+
+```typescript
+logger.log('User created', { userId: 1 }, { email: 'a@b.com' })
+// params: { userId: 1, email: 'a@b.com' }
+```
+
+Opt out with Nest's escape hatch so objects stay as extra message arguments:
+
+```typescript
+const logger = new Logger('UserService', { structuredParams: false })
+logger.log('User created', { userId: 1 })
+```
+
+`logLevels` now actually apply:
+
+```typescript
+const logger = new Logger('UserService', {
+  logLevels: ['error', 'fatal', 'warn'],
+})
+logger.debug('skipped')
+```
+
 ## Custom logger instance (files, wrapAll, hooks)
 
 Use `createLogger` (alias for `createLoggerConsola` from core), optionally call `Logger.setLoggerInstance` before `app.useLogger`:
 
 ```typescript
 import path from 'node:path'
+
 import { createLogger, Logger } from '@innei/pretty-logger-nestjs'
 import { NestFactory } from '@nestjs/core'
+
 import { AppModule } from './app.module'
 
 const customLogger = createLogger({

--- a/packages/nest/logger.service.spec.ts
+++ b/packages/nest/logger.service.spec.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Logger } from './logger.service'
+
+function stripAnsi(value: string) {
+  return value.replace(/\u001B\[[0-9;]*m/g, '')
+}
+
+function createMockConsola() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    verbose: vi.fn(),
+    fatal: vi.fn(),
+  }
+}
+
+describe('Logger', () => {
+  let consola: ReturnType<typeof createMockConsola>
+
+  beforeEach(() => {
+    consola = createMockConsola()
+    Logger.setLoggerInstance(consola as any)
+  })
+
+  it('treats trailing context and a plain object as one consola call with params', () => {
+    const logger = new Logger()
+    logger.log('msg', { userId: 1 }, 'UserService')
+
+    expect(consola.info).toHaveBeenCalledTimes(1)
+    const args = consola.info.mock.calls[0]
+    expect(stripAnsi(args[0])).toBe('[UserService]')
+    expect(args[1]).toBe('msg')
+    expect(args[2]).toEqual({ userId: 1 })
+    expect(args).toHaveLength(3)
+  })
+
+  it('merges extra plain objects into one params argument', () => {
+    const logger = new Logger()
+    logger.log('msg', { a: 1 }, { b: 2 })
+
+    expect(consola.info).toHaveBeenCalledTimes(1)
+    const args = consola.info.mock.calls[0]
+    expect(args[1]).toBe('msg')
+    expect(args[2]).toEqual({ a: 1, b: 2 })
+    expect(args).toHaveLength(3)
+  })
+
+  it('keeps objects as extra message args when structuredParams is false', () => {
+    const logger = new Logger('', { structuredParams: false })
+    logger.log('msg', { a: 1 }, { b: 2 })
+
+    expect(consola.info).toHaveBeenCalledTimes(1)
+    const args = consola.info.mock.calls[0]
+    expect(args[1]).toBe('msg')
+    expect(args[2]).toEqual({ a: 1 })
+    expect(args[3]).toEqual({ b: 2 })
+    expect(args).toHaveLength(4)
+  })
+
+  it('treats a trailing non-PascalCase string as context', () => {
+    const logger = new Logger()
+    logger.log('msg', 'my-context')
+
+    expect(consola.info).toHaveBeenCalledTimes(1)
+    const args = consola.info.mock.calls[0]
+    expect(stripAnsi(args[0])).toBe('[my-context]')
+    expect(args[1]).toBe('msg')
+  })
+
+  it('passes error stack and context through to consola', () => {
+    const logger = new Logger()
+    const stack =
+      'Error: boom\n    at UserService.create (user.service.ts:10:5)'
+    logger.error('boom', stack, 'UserService')
+
+    expect(consola.error).toHaveBeenCalledTimes(1)
+    const args = consola.error.mock.calls[0]
+    expect(stripAnsi(args[0])).toBe('[UserService]')
+    expect(args[1]).toBe('boom')
+    expect(args[2]).toBe(stack)
+  })
+
+  it('honors logLevels and suppresses log/warn when only error is enabled', () => {
+    const logger = new Logger('', { logLevels: ['error'] })
+    logger.log('hidden')
+    logger.warn('hidden')
+
+    expect(consola.info).not.toHaveBeenCalled()
+    expect(consola.warn).not.toHaveBeenCalled()
+
+    logger.error('visible')
+    expect(consola.error).toHaveBeenCalledTimes(1)
+    expect(consola.error.mock.calls[0][1]).toBe('visible')
+  })
+})

--- a/packages/nest/logger.service.spec.ts
+++ b/packages/nest/logger.service.spec.ts
@@ -25,7 +25,7 @@ describe('Logger', () => {
     Logger.setLoggerInstance(consola as any)
   })
 
-  it('treats trailing context and a plain object as one consola call with params', () => {
+  it('treats a trailing PascalCase string as Nest context', () => {
     const logger = new Logger()
     logger.log('msg', { userId: 1 }, 'UserService')
 
@@ -34,43 +34,32 @@ describe('Logger', () => {
     expect(stripAnsi(args[0])).toBe('[UserService]')
     expect(args[1]).toBe('msg')
     expect(args[2]).toEqual({ userId: 1 })
-    expect(args).toHaveLength(3)
   })
 
-  it('merges extra plain objects into one params argument', () => {
+  it('keeps extra objects as separate message args', () => {
     const logger = new Logger()
     logger.log('msg', { a: 1 }, { b: 2 })
 
     expect(consola.info).toHaveBeenCalledTimes(1)
     const args = consola.info.mock.calls[0]
-    expect(args[1]).toBe('msg')
-    expect(args[2]).toEqual({ a: 1, b: 2 })
-    expect(args).toHaveLength(3)
-  })
-
-  it('keeps objects as extra message args when structuredParams is false', () => {
-    const logger = new Logger('', { structuredParams: false })
-    logger.log('msg', { a: 1 }, { b: 2 })
-
-    expect(consola.info).toHaveBeenCalledTimes(1)
-    const args = consola.info.mock.calls[0]
+    expect(stripAnsi(args[0])).toBe('[System]')
     expect(args[1]).toBe('msg')
     expect(args[2]).toEqual({ a: 1 })
     expect(args[3]).toEqual({ b: 2 })
-    expect(args).toHaveLength(4)
   })
 
-  it('treats a trailing non-PascalCase string as context', () => {
+  it('keeps a trailing non-PascalCase string as a message, not context', () => {
     const logger = new Logger()
     logger.log('msg', 'my-context')
 
     expect(consola.info).toHaveBeenCalledTimes(1)
     const args = consola.info.mock.calls[0]
-    expect(stripAnsi(args[0])).toBe('[my-context]')
+    expect(stripAnsi(args[0])).toBe('[System]')
     expect(args[1]).toBe('msg')
+    expect(args[2]).toBe('my-context')
   })
 
-  it('passes error stack and context through to consola', () => {
+  it('passes error stack through as a message arg with PascalCase context', () => {
     const logger = new Logger()
     const stack =
       'Error: boom\n    at UserService.create (user.service.ts:10:5)'
@@ -83,16 +72,14 @@ describe('Logger', () => {
     expect(args[2]).toBe(stack)
   })
 
-  it('honors logLevels and suppresses log/warn when only error is enabled', () => {
+  it('always prints debug even when logLevels omit it', () => {
     const logger = new Logger('', { logLevels: ['error'] })
-    logger.log('hidden')
-    logger.warn('hidden')
+    logger.debug('still-visible')
+    logger.log('also-visible')
 
-    expect(consola.info).not.toHaveBeenCalled()
-    expect(consola.warn).not.toHaveBeenCalled()
-
-    logger.error('visible')
-    expect(consola.error).toHaveBeenCalledTimes(1)
-    expect(consola.error.mock.calls[0][1]).toBe('visible')
+    expect(consola.debug).toHaveBeenCalledTimes(1)
+    expect(consola.debug.mock.calls[0][1]).toBe('still-visible')
+    expect(consola.info).toHaveBeenCalledTimes(1)
+    expect(consola.info.mock.calls[0][1]).toBe('also-visible')
   })
 })

--- a/packages/nest/logger.service.ts
+++ b/packages/nest/logger.service.ts
@@ -6,15 +6,18 @@ import type { ConsoleLoggerOptions } from '@nestjs/common'
 import { createLoggerConsola } from '@innei/pretty-logger-core'
 import { ConsoleLogger } from '@nestjs/common'
 
-type LogLevel =
+type ConsolaPrintLevel =
   | 'info'
-  | 'log'
   | 'error'
   | 'warn'
   | 'debug'
   | 'verbose'
   | 'fatal'
 
+/**
+ * Pretty TTY/file Nest logger. Does not implement ConsoleLogger `json` /
+ * `flattenParams` modes — use Nest's built-in JSON logger for that path.
+ */
 export class Logger extends ConsoleLogger {
   private static loggerInstance = createLoggerConsola()
 
@@ -48,66 +51,80 @@ export class Logger extends ConsoleLogger {
       : ''
   }
 
-  /**
-   * Check if the last argument looks like a NestJS context string.
-   * NestJS passes context as the last string argument (e.g., 'AppService', 'UserController').
-   * Context strings are typically PascalCase class names.
-   */
-  private isContextString(value: unknown): value is string {
-    if (typeof value !== 'string') return false
-    // Context is usually a short PascalCase identifier (class name)
-    // Not a sentence, not a path, not containing spaces or special chars
-    return /^[A-Z][a-zA-Z0-9]*$/.test(value)
-  }
-
-  private print(level: LogLevel, ...args: any[]) {
+  private flush(
+    level: ConsolaPrintLevel,
+    messages: unknown[],
+    context?: string,
+    params?: Record<string, unknown>,
+    stack?: unknown,
+  ) {
     const print = Logger.loggerInstance[level] as (...args: any[]) => void
     const diff = this._updateAndGetTimestampDiff()
-
-    let context: string | undefined
-    let messages = args
-
-    // Check if the last argument is a context string (NestJS convention)
-    if (args.length > 0 && this.isContextString(args.at(-1))) {
-      context = args.at(-1)
-      messages = args.slice(0, -1)
-    }
-
     const prefix = this.workerPrefix
       ? `${this.workerPrefix} ${this.getContextPrefix(context)}`
       : this.getContextPrefix(context)
 
-    const output = [prefix, ...messages, diff].filter(
+    const output = [prefix, ...messages, params, stack, diff].filter(
       (v) => v !== undefined && v !== '',
     )
     print(...output)
   }
 
   log(...args: any[]) {
-    this.print('info', ...args)
+    if (!this.isLevelEnabled('log')) {
+      return
+    }
+    const { messages, context, params } =
+      this.getContextAndMessagesToPrint(args)
+    this.flush('info', messages, context, params)
   }
 
   info(...args: any[]) {
-    this.print('info', ...args)
+    this.log(...args)
   }
 
   warn(...args: any[]) {
-    this.print('warn', ...args)
+    if (!this.isLevelEnabled('warn')) {
+      return
+    }
+    const { messages, context, params } =
+      this.getContextAndMessagesToPrint(args)
+    this.flush('warn', messages, context, params)
   }
 
   debug(...args: any[]) {
-    this.print('debug', ...args)
+    if (!this.isLevelEnabled('debug')) {
+      return
+    }
+    const { messages, context, params } =
+      this.getContextAndMessagesToPrint(args)
+    this.flush('debug', messages, context, params)
   }
 
   verbose(...args: any[]) {
-    this.print('verbose', ...args)
+    if (!this.isLevelEnabled('verbose')) {
+      return
+    }
+    const { messages, context, params } =
+      this.getContextAndMessagesToPrint(args)
+    this.flush('verbose', messages, context, params)
   }
 
   fatal(...args: any[]) {
-    this.print('fatal', ...args)
+    if (!this.isLevelEnabled('fatal')) {
+      return
+    }
+    const { messages, context, params } =
+      this.getContextAndMessagesToPrint(args)
+    this.flush('fatal', messages, context, params)
   }
 
   error(...args: any[]) {
-    this.print('error', ...args)
+    if (!this.isLevelEnabled('error')) {
+      return
+    }
+    const { messages, context, stack, params } =
+      this.getContextAndStackAndMessagesToPrint(args)
+    this.flush('error', messages, context, params, stack)
   }
 }

--- a/packages/nest/logger.service.ts
+++ b/packages/nest/logger.service.ts
@@ -6,18 +6,15 @@ import type { ConsoleLoggerOptions } from '@nestjs/common'
 import { createLoggerConsola } from '@innei/pretty-logger-core'
 import { ConsoleLogger } from '@nestjs/common'
 
-type ConsolaPrintLevel =
+type LogLevel =
   | 'info'
+  | 'log'
   | 'error'
   | 'warn'
   | 'debug'
   | 'verbose'
   | 'fatal'
 
-/**
- * Pretty TTY/file Nest logger. Does not implement ConsoleLogger `json` /
- * `flattenParams` modes — use Nest's built-in JSON logger for that path.
- */
 export class Logger extends ConsoleLogger {
   private static loggerInstance = createLoggerConsola()
 
@@ -51,80 +48,66 @@ export class Logger extends ConsoleLogger {
       : ''
   }
 
-  private flush(
-    level: ConsolaPrintLevel,
-    messages: unknown[],
-    context?: string,
-    params?: Record<string, unknown>,
-    stack?: unknown,
-  ) {
+  /**
+   * Check if the last argument looks like a NestJS context string.
+   * NestJS passes context as the last string argument (e.g., 'AppService', 'UserController').
+   * Context strings are typically PascalCase class names.
+   */
+  private isContextString(value: unknown): value is string {
+    if (typeof value !== 'string') return false
+    // Context is usually a short PascalCase identifier (class name)
+    // Not a sentence, not a path, not containing spaces or special chars
+    return /^[A-Z][a-zA-Z0-9]*$/.test(value)
+  }
+
+  private print(level: LogLevel, ...args: any[]) {
     const print = Logger.loggerInstance[level] as (...args: any[]) => void
     const diff = this._updateAndGetTimestampDiff()
+
+    let context: string | undefined
+    let messages = args
+
+    // Check if the last argument is a context string (NestJS convention)
+    if (args.length > 0 && this.isContextString(args.at(-1))) {
+      context = args.at(-1)
+      messages = args.slice(0, -1)
+    }
+
     const prefix = this.workerPrefix
       ? `${this.workerPrefix} ${this.getContextPrefix(context)}`
       : this.getContextPrefix(context)
 
-    const output = [prefix, ...messages, params, stack, diff].filter(
+    const output = [prefix, ...messages, diff].filter(
       (v) => v !== undefined && v !== '',
     )
     print(...output)
   }
 
   log(...args: any[]) {
-    if (!this.isLevelEnabled('log')) {
-      return
-    }
-    const { messages, context, params } =
-      this.getContextAndMessagesToPrint(args)
-    this.flush('info', messages, context, params)
+    this.print('info', ...args)
   }
 
   info(...args: any[]) {
-    this.log(...args)
+    this.print('info', ...args)
   }
 
   warn(...args: any[]) {
-    if (!this.isLevelEnabled('warn')) {
-      return
-    }
-    const { messages, context, params } =
-      this.getContextAndMessagesToPrint(args)
-    this.flush('warn', messages, context, params)
+    this.print('warn', ...args)
   }
 
   debug(...args: any[]) {
-    if (!this.isLevelEnabled('debug')) {
-      return
-    }
-    const { messages, context, params } =
-      this.getContextAndMessagesToPrint(args)
-    this.flush('debug', messages, context, params)
+    this.print('debug', ...args)
   }
 
   verbose(...args: any[]) {
-    if (!this.isLevelEnabled('verbose')) {
-      return
-    }
-    const { messages, context, params } =
-      this.getContextAndMessagesToPrint(args)
-    this.flush('verbose', messages, context, params)
+    this.print('verbose', ...args)
   }
 
   fatal(...args: any[]) {
-    if (!this.isLevelEnabled('fatal')) {
-      return
-    }
-    const { messages, context, params } =
-      this.getContextAndMessagesToPrint(args)
-    this.flush('fatal', messages, context, params)
+    this.print('fatal', ...args)
   }
 
   error(...args: any[]) {
-    if (!this.isLevelEnabled('error')) {
-      return
-    }
-    const { messages, context, stack, params } =
-      this.getContextAndStackAndMessagesToPrint(args)
-    this.flush('error', messages, context, params, stack)
+    this.print('error', ...args)
   }
 }

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -26,5 +26,8 @@
   "devDependencies": {
     "@nestjs/common": "^12",
     "@oxc-project/runtime": "^0.70.0"
-  }
+  },
+  "files": [
+    "dist"
+  ]
 }

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innei/pretty-logger-nestjs",
-  "version": "0.4.2",
+  "version": "1.0.0",
   "exports": {
     ".": {
       "require": "./dist/index.js",
@@ -14,7 +14,7 @@
     "build": "tsdown"
   },
   "peerDependencies": {
-    "@nestjs/common": ">=10"
+    "@nestjs/common": "^12"
   },
   "dependencies": {
     "@innei/pretty-logger-core": "workspace:*",
@@ -24,6 +24,7 @@
     "std-env": "^3.5.0"
   },
   "devDependencies": {
+    "@nestjs/common": "^12",
     "@oxc-project/runtime": "^0.70.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 0.15.0
         version: 0.15.0
       '@nestjs/common':
-        specifier: ^11.1.1
-        version: 11.1.1(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        specifier: ^12
+        version: 12.0.1(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@types/node':
         specifier: 22.15.18
         version: 22.15.18
@@ -169,9 +169,6 @@ importers:
       '@innei/pretty-logger-core':
         specifier: workspace:*
         version: link:../core
-      '@nestjs/common':
-        specifier: '>=10'
-        version: 11.1.1(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cron:
         specifier: 4.3.0
         version: 4.3.0
@@ -185,6 +182,9 @@ importers:
         specifier: ^3.5.0
         version: 3.9.0
     devDependencies:
+      '@nestjs/common':
+        specifier: ^12
+        version: 12.0.1(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@oxc-project/runtime':
         specifier: ^0.70.0
         version: 0.70.0
@@ -421,6 +421,9 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -1015,42 +1018,49 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-arm64-musl@1.0.1':
     resolution: {integrity: sha512-wG8fa2VKuWM4CfjOjjRX9YLIbysSVV1S3Kgm2Fnc67ap/soHBeYZa6AGMeR5BJAylYRjnoVOzV19Cmkco3QEPw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-linux-ppc64-gnu@1.0.1':
     resolution: {integrity: sha512-lxQ9WrBf0IlNTCA9oS2jg/iAjQyTI6JHzABV664LLrLA/SIdD+I1i3Mjf7TsnoUbgopBcCuDztVLfJ0q9ubf6Q==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-riscv64-gnu@1.0.1':
     resolution: {integrity: sha512-3xs69dO8WSWBb13KBVex+yvxmUeEsdWexxibqskzoKaWx9AIqkMbWmE2npkazJoopPKX2ULKd8Fm9veEn0g4Ig==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-s390x-gnu@1.0.1':
     resolution: {integrity: sha512-lMFI3i9rlW7hgToyAzTaEybQYGbQHDrpRkg+1gJWEpH0PLAQoZ8jiY0IzakLfNWnVda1eTYYlxxFYzW8Rqczkg==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-gnu@1.0.1':
     resolution: {integrity: sha512-XQAJs7DRN2GpLN6Fb+ZdGFeYZDdGl2Fn3TmFlqEL5JorgWKrQGRUrpGKbgZ25UeZPILuTKJ+OowG2avN8mThBA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-musl@1.0.1':
     resolution: {integrity: sha512-/rodHpRSgiI9o1faq9SZOp/o2QkKQg7T+DK0R5AkbnI/YxvAIEHf2cngjYzLMQSQgUhxym+LFr+UGZx4vK4QdQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-win32-arm64-msvc@1.0.1':
     resolution: {integrity: sha512-rEcz9vZymaCB3OqEXoHnp9YViLct8ugF+6uO5McifTedjq4QMQs3DHz35xBEGhH3gJWEsXMUbzazkz5KNM5YUg==}
@@ -1092,6 +1102,19 @@ packages:
 
   '@nestjs/common@11.1.1':
     resolution: {integrity: sha512-crzp+1qeZ5EGL0nFTPy9NrVMAaUWewV5AwtQyv6SQ9yQPXwRl9W9hm1pt0nAtUu5QbYMbSuo7lYcF81EjM+nCA==}
+    peerDependencies:
+      class-transformer: '>=0.4.1'
+      class-validator: '>=0.13.2'
+      reflect-metadata: ^0.1.12 || ^0.2.0
+      rxjs: ^7.1.0
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+
+  '@nestjs/common@12.0.1':
+    resolution: {integrity: sha512-v0zTaRCTV2K2xSnb3GnJoQKtaR6VxouJtm+P2gpr5w61dlXeWpXl1WVknCSzUqx2QwTV10tBkHETxvQvkf2Exg==}
     peerDependencies:
       class-transformer: '>=0.4.1'
       class-validator: '>=0.13.2'
@@ -1216,21 +1239,25 @@ packages:
     resolution: {integrity: sha512-ItBOhvZtYHIGJ1AtX7xf7v0RvZbXgdsv5gHk8vDykGMAbl+t4Wa9OJIIa6C8V2nBFJXWH+14GudrEfQfQUFbtQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.8-commit.d95f99e':
     resolution: {integrity: sha512-UiHjNo1ffN9Nt53mmawmnuVn2l9vdYGd91XxFrOTrEKRxO5bJL6wBhd82t+uBeHWycR/6qlSCJkTsHJQPf2UbA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.8-commit.d95f99e':
     resolution: {integrity: sha512-p3sIHw1vmqqK70474mEvyl0aj1PvvUEWiKxG+zvpNRTzWxcTxrsRCtlqxTJ1A8R0z76tdn00PsMQrFOSMnLotQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.8-commit.d95f99e':
     resolution: {integrity: sha512-STOhk06GmHu/mvrZnp32JkQAN07g1ZjuaChf8r0/7NnnOIg6xiTcBxhMxL5hTR7os075ziRRUoHlfEssIJxSBw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.8-commit.d95f99e':
     resolution: {integrity: sha512-18l5SdnDs49KuWsJ1ZjxQ72f4OBv++wQDkYeTkIDFON+lWIY6pCc4Zb7ehD8aflq6gisokt0GsZWO8Dyi7iqrA==}
@@ -1289,56 +1316,67 @@ packages:
     resolution: {integrity: sha512-46OzWeqEVQyX3N2/QdiU/CMXYDH/lSHpgfBkuhl3igpZiaB3ZIfSjKuOnybFVBQzjsLwkus2mjaESy8H41SzvA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.41.0':
     resolution: {integrity: sha512-lfgW3KtQP4YauqdPpcUZHPcqQXmTmH4nYU0cplNeW583CMkAGjtImw4PKli09NFi2iQgChk4e9erkwlfYem6Lg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.41.0':
     resolution: {integrity: sha512-nn8mEyzMbdEJzT7cwxgObuwviMx6kPRxzYiOl6o/o+ChQq23gfdlZcUNnt89lPhhz3BYsZ72rp0rxNqBSfqlqw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.41.0':
     resolution: {integrity: sha512-l+QK99je2zUKGd31Gh+45c4pGDAqZSuWQiuRFCdHYC2CSiO47qUWsCcenrI6p22hvHZrDje9QjwSMAFL3iwXwQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.41.0':
     resolution: {integrity: sha512-WbnJaxPv1gPIm6S8O/Wg+wfE/OzGSXlBMbOe4ie+zMyykMOeqmgD1BhPxZQuDqwUN+0T/xOFtL2RUWBspnZj3w==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.41.0':
     resolution: {integrity: sha512-eRDWR5t67/b2g8Q/S8XPi0YdbKcCs4WQ8vklNnUYLaSWF+Cbv2axZsp4jni6/j7eKvMLYCYdcsv8dcU+a6QNFg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.41.0':
     resolution: {integrity: sha512-TWrZb6GF5jsEKG7T1IHwlLMDRy2f3DPqYldmIhnA2DVqvvhY2Ai184vZGgahRrg8k9UBWoSlHv+suRfTN7Ua4A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.41.0':
     resolution: {integrity: sha512-ieQljaZKuJpmWvd8gW87ZmSFwid6AxMDk5bhONJ57U8zT77zpZ/TPKkU9HpnnFrM4zsgr4kiGuzbIbZTGi7u9A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.41.0':
     resolution: {integrity: sha512-/L3pW48SxrWAlVsKCN0dGLB2bi8Nv8pr5S5ocSM+S0XCn5RCVCXqi8GVtHFsOBBCSeR+u9brV2zno5+mg3S4Aw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.41.0':
     resolution: {integrity: sha512-XMLeKjyH8NsEDCRptf6LO8lJk23o9wvB+dJwcXMaH6ZQbbkHu2dbGIUindbMtRN6ux1xKi16iXWu6q9mu7gDhQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.41.0':
     resolution: {integrity: sha512-m/P7LycHZTvSQeXhFmgmdqEiTqSV80zn6xHaQ1JSqwCtD1YGtwEK515Qmy9DcB2HK4dOUVypQxvhVSy06cJPEg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.41.0':
     resolution: {integrity: sha512-4yodtcOrFHpbomJGVEqZ8fzD4kfBeCbpsUy5Pqk4RluXOdsWdjLnjhiKy2w3qzcASWd04fp52Xz7JKarVJ5BTg==}
@@ -1370,6 +1408,9 @@ packages:
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@stylistic/eslint-plugin@4.2.0':
     resolution: {integrity: sha512-8hXezgz7jexGHdo5WN6JBEIPHCSFyyU4vgbxevu4YLVS5vl+sxqAAGyXSzfNDyR6xMNSH5H1x67nsXcYMOHtZA==}
@@ -1411,24 +1452,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.11.24':
     resolution: {integrity: sha512-ypXLIdszRo0re7PNNaXN0+2lD454G8l9LPK/rbfRXnhLWDBPURxzKlLlU/YGd2zP98wPcVooMmegRSNOKfvErw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.11.24':
     resolution: {integrity: sha512-IM7d+STVZD48zxcgo69L0yYptfhaaE9cMZ+9OoMxirNafhKKXwoZuufol1+alEFKc+Wbwp+aUPe/DeWC/Lh3dg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.11.24':
     resolution: {integrity: sha512-DZByJaMVzSfjQKKQn3cqSeqwy6lpMaQDQQ4HPlch9FWtDx/dLcpdIhxssqZXcR2rhaQVIaRQsCqwV6orSDGAGw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.11.24':
     resolution: {integrity: sha512-Q64Ytn23y9aVDKN5iryFi8mRgyHw3/kyjTjT4qFCa8AEb5sGUuSj//AUZ6c0J7hQKMHlg9do5Etvoe61V98/JQ==}
@@ -1469,6 +1514,10 @@ packages:
 
   '@tokenizer/inflate@0.2.7':
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
 
   '@tokenizer/token@0.3.0':
@@ -1698,41 +1747,49 @@ packages:
     resolution: {integrity: sha512-jon9M7DKRLGZ9VYSkFMflvNqu9hDtOCEnO2QAryFWgT6o6AXU8du56V7YqnaLKr6rAbZBWYsYpikF226v423QA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.7.2':
     resolution: {integrity: sha512-c8Cg4/h+kQ63pL43wBNaVMmOjXI/X62wQmru51qjfTvI7kmCy5uHTJvK/9LrF0G8Jdx8r34d019P1DVJmhXQpA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.7.2':
     resolution: {integrity: sha512-A+lcwRFyrjeJmv3JJvhz5NbcCkLQL6Mk16kHTNm6/aGNc4FwPHPE4DR9DwuCvCnVHvF5IAd9U4VIs/VvVir5lg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.7.2':
     resolution: {integrity: sha512-hQQ4TJQrSQW8JlPm7tRpXN8OCNP9ez7PajJNjRD1ZTHQAy685OYqPrKjfaMw/8LiHCt8AZ74rfUVHP9vn0N69Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.7.2':
     resolution: {integrity: sha512-NoAGbiqrxtY8kVooZ24i70CjLDlUFI7nDj3I9y54U94p+3kPxwd2L692YsdLa+cqQ0VoqMWoehDFp21PKRUoIQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.7.2':
     resolution: {integrity: sha512-KaZByo8xuQZbUhhreBTW+yUnOIHUsv04P8lKjQ5otiGoSJ17ISGYArc+4vKdLEpGaLbemGzr4ZeUbYQQsLWFjA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.7.2':
     resolution: {integrity: sha512-dEidzJDubxxhUCBJ/SHSMJD/9q7JkyfBMT77Px1npl4xpg9t0POLvnWywSk66BgZS/b2Hy9Y1yFaoMTFJUe9yg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.7.2':
     resolution: {integrity: sha512-RvP+Ux3wDjmnZDT4XWFfNBRVG0fMsc+yVzNFUqOflnDfZ9OYujv6nkh+GOr+watwrW4wdp6ASfG/e7bkDradsw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.7.2':
     resolution: {integrity: sha512-y797JBmO9IsvXVRCKDXOxjyAE4+CcZpla2GSoBQ33TVb3ILXuFnMrbR/QQZoauBYeOFuu4w3ifWLw52sdHGz6g==}
@@ -1879,6 +1936,7 @@ packages:
 
   '@zod/mini@4.0.0-beta.20250505T195954':
     resolution: {integrity: sha512-ioybPtU4w4TqwHvJv0gkAiYNaBkZ/BaGHBpK7viCIRSE8BiiZucVZ8vS0YE04Qy1R120nAnFy1d+tD9ByMO0yw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -2059,12 +2117,14 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   autocorrect-node-linux-x64-musl@2.14.0:
     resolution: {integrity: sha512-3LifiLG61VIXBrOITpD/REcg/ZEUuLz/P2XUWMCfGqhzoUb8oFgM3o0A6extvIH2NefiHMndB9kNbfQjXCl3zA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   autocorrect-node-win32-x64-msvc@2.14.0:
     resolution: {integrity: sha512-OM6TeGUW0+4R9KtUYTYNEwlInd+b2kumw/B1HCbCzb1F7HpfaNxnZiMk1li0bdPPBDzD5YuzwM30VJZMCWIi5A==}
@@ -2417,10 +2477,12 @@ packages:
   conventional-changelog-atom@2.0.8:
     resolution: {integrity: sha512-xo6v46icsFTK3bb7dY/8m2qvc8sZemRgdqLb/bjpBsH2UyOS8rKNTgcb5025Hri6IpANPApbXMg15QLb1LJpBw==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-codemirror@2.0.8:
     resolution: {integrity: sha512-z5DAsn3uj1Vfp7po3gpt2Boc+Bdwmw2++ZHa5Ak9k0UKsYAO5mH1UBTN0qSCuJZREIhX6WU4E1p3IW2oRCNzQw==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-conventionalcommits@4.6.3:
     resolution: {integrity: sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==}
@@ -2429,26 +2491,32 @@ packages:
   conventional-changelog-core@4.2.4:
     resolution: {integrity: sha512-gDVS+zVJHE2v4SLc6B0sLsPiloR0ygU7HaDW14aNJE1v4SlqJPILPl/aJC7YdtRE4CybBf8gDwObBvKha8Xlyg==}
     engines: {node: '>=10'}
+    deprecated: Deprecated and no longer maintained. Please use conventional-changelog instead.
 
   conventional-changelog-ember@2.0.9:
     resolution: {integrity: sha512-ulzIReoZEvZCBDhcNYfDIsLTHzYHc7awh+eI44ZtV5cx6LVxLlVtEmcO+2/kGIHGtw+qVabJYjdI5cJOQgXh1A==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-eslint@3.0.9:
     resolution: {integrity: sha512-6NpUCMgU8qmWmyAMSZO5NrRd7rTgErjrm4VASam2u5jrZS0n38V7Y9CzTtLT2qwz5xEChDR4BduoWIr8TfwvXA==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-express@2.0.6:
     resolution: {integrity: sha512-SDez2f3iVJw6V563O3pRtNwXtQaSmEfTCaTBPCqn0oG0mfkq0rX4hHBq5P7De2MncoRixrALj3u3oQsNK+Q0pQ==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-jquery@3.0.11:
     resolution: {integrity: sha512-x8AWz5/Td55F7+o/9LQ6cQIPwrCjfJQ5Zmfqi8thwUEKHstEn4kTIofXub7plf1xvFA2TqhZlq7fy5OmV6BOMw==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-jshint@2.0.9:
     resolution: {integrity: sha512-wMLdaIzq6TNnMHMy31hql02OEQ8nCQfExw1SE0hYL5KvU+JCTuPaDO+7JiogGT2gJAxiUGATdtYYfh+nT+6riA==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-preset-loader@2.3.4:
     resolution: {integrity: sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==}
@@ -2547,6 +2615,15 @@ packages:
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -2982,6 +3059,7 @@ packages:
   eslint@9.27.0:
     resolution: {integrity: sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -3124,6 +3202,10 @@ packages:
   file-type@20.5.0:
     resolution: {integrity: sha512-BfHZtG/l9iMm4Ecianu7P8HRD2tBHLtjXinm4X62XBOYzi7CYA7jyqfJzOvXHqzVrVPYqBo2/GvbARMaaJkKVg==}
     engines: {node: '>=18'}
+
+  file-type@22.0.2:
+    resolution: {integrity: sha512-0H8TsCUGBLx+V5adH3EY52hTAcyLKbV1D4gq5cIOJ6DnQAHeV9Z2Hhuc5CoBX4YmvB2oL+JIC84z0qO7JsCoNw==}
+    engines: {node: '>=22'}
 
   filelist@1.0.4:
     resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
@@ -3270,6 +3352,7 @@ packages:
   git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -3279,6 +3362,7 @@ packages:
   git-semver-tags@4.1.1:
     resolution: {integrity: sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==}
     engines: {node: '>=10'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   gitconfiglocal@1.0.0:
@@ -3297,16 +3381,18 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.1:
     resolution: {integrity: sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -3852,6 +3938,10 @@ packages:
     resolution: {integrity: sha512-nVAvWk/jeyrWyXEAs84mpQCYccxRqgKY4OznLuJhJCa0XsPSfdOIr2zvBZEj3IHEHbX97jjscKRRV539bW0Gpw==}
     engines: {node: '>=13.2.0'}
 
+  load-esm@1.0.3:
+    resolution: {integrity: sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==}
+    engines: {node: '>=13.2.0'}
+
   load-json-file@4.0.0:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
     engines: {node: '>=4'}
@@ -4069,6 +4159,7 @@ packages:
   multer@1.4.5-lts.2:
     resolution: {integrity: sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==}
     engines: {node: '>= 6.0.0'}
+    deprecated: Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.
 
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
@@ -4990,6 +5081,10 @@ packages:
     resolution: {integrity: sha512-Xt18+h4s7Z8xyZ0tmBoRmzxcop97R4BAh+dXouUDCYn+Em+1P3qpkUfI5ueWLT8ynC5hZ+q4iPEmGG1urvQGBg==}
     engines: {node: '>=18'}
 
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
+
   strtok3@9.1.1:
     resolution: {integrity: sha512-FhwotcEqjr241ZbjFzjlIYg6c5/L/s4yBGWSMvJ9UoExiSqL+FnFA/CaeZx17WGaZMS/4SOZp8wH18jSS4R4lw==}
     engines: {node: '>=16'}
@@ -5002,10 +5097,12 @@ packages:
   superagent@10.2.1:
     resolution: {integrity: sha512-O+PCv11lgTNJUzy49teNAWLjBZfc+A1enOwTpLlH6/rsvKcTwcdTT8m9azGkVqM7HBl5jpyZ7KTPhHweokBcdg==}
     engines: {node: '>=14.18.0'}
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   supertest@7.1.1:
     resolution: {integrity: sha512-aI59HBTlG9e2wTjxGJV+DygfNLgnWbGdZxiA/sgrnNNikIW8lbDvCtF6RnhZoJ82nU7qv7ZLjrvWqCEm52fAmw==}
     engines: {node: '>=14.18.0'}
+    deprecated: Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -5144,6 +5241,10 @@ packages:
     resolution: {integrity: sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==}
     engines: {node: '>=14.16'}
 
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
+
   touch@3.1.1:
     resolution: {integrity: sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==}
     hasBin: true
@@ -5221,6 +5322,7 @@ packages:
   tsconfck@3.1.5:
     resolution: {integrity: sha512-CLDfGgUp7XPswWnezWwsCRxNmgQjhYq3VXHM0/XIRxhVrKw0M1if9agzryh1QS3nxjCROvV+xWxoJO1YctzzWg==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -5323,6 +5425,10 @@ packages:
 
   uint8array-extras@1.4.0:
     resolution: {integrity: sha512-ZPtzy0hu4cZjv3z5NW9gfKnNLjoz4y6uv4HlelAjDK7sY/xOkKZv9xK/WQpcsBB3jEybChz9DPC2U/+cusjJVQ==}
+    engines: {node: '>=18'}
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
 
   unbzip2-stream@1.4.3:
@@ -5896,6 +6002,8 @@ snapshots:
       '@babel/helper-validator-identifier': 7.27.1
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@borewit/text-codec@0.2.2': {}
 
   '@colors/colors@1.5.0':
     optional: true
@@ -6687,6 +6795,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nestjs/common@12.0.1(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      file-type: 22.0.2
+      iterare: 1.2.1
+      load-esm: 1.0.3
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      uid: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@nestjs/core@11.1.1(@nestjs/common@11.1.1(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 11.1.1(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -6883,6 +7004,8 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@stylistic/eslint-plugin@4.2.0(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/utils': 8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3)
@@ -6971,6 +7094,13 @@ snapshots:
       debug: 4.4.1(supports-color@5.5.0)
       fflate: 0.8.2
       token-types: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -8165,6 +8295,10 @@ snapshots:
     optionalDependencies:
       supports-color: 5.5.0
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   decamelize-keys@1.1.1:
     dependencies:
       decamelize: 1.2.0
@@ -8877,6 +9011,15 @@ snapshots:
       strtok3: 10.2.2
       token-types: 6.0.0
       uint8array-extras: 1.4.0
+    transitivePeerDependencies:
+      - supports-color
+
+  file-type@22.0.2:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9779,6 +9922,8 @@ snapshots:
       wrap-ansi: 9.0.0
 
   load-esm@1.0.2: {}
+
+  load-esm@1.0.3: {}
 
   load-json-file@4.0.0:
     dependencies:
@@ -10874,6 +11019,10 @@ snapshots:
       '@tokenizer/token': 0.3.0
       peek-readable: 7.0.0
 
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
   strtok3@9.1.1:
     dependencies:
       '@tokenizer/token': 0.3.0
@@ -11060,6 +11209,12 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
   touch@3.1.1: {}
 
   tree-kill@1.2.2: {}
@@ -11222,6 +11377,8 @@ snapshots:
       '@lukeed/csprng': 1.1.0
 
   uint8array-extras@1.4.0: {}
+
+  uint8array-extras@1.5.0: {}
 
   unbzip2-stream@1.4.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,8 @@ packages:
   - packages/*
   - demo
 strictPeerDependencies: false
+allowBuilds:
+  '@swc/core': true
+  esbuild: true
+  unrs-resolver: true
+  '@nestjs/core': false

--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ async function bootstrap() {
 bootstrap()
 ```
 
-Structured params (Nest 12 default): `logger.log('User created', { userId: 1 })` attaches the object as metadata of that entry. Set `structuredParams: false` on the logger options to keep objects as extra message arguments. `logLevels` are honored. This package is the pretty TTY/file path — it does not implement Nest `json` / `flattenParams`.
+Print behavior matches 0.4.2. This package is the pretty TTY/file path — it does not implement Nest `json` / `flattenParams`.
 
 > [!WARNING]
 > After `wrapAll()`, avoid using `console.log` (or other wrapped stdio) inside `onData` to prevent feedback loops.

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ pnpm add @innei/pretty-logger-nestjs
 # or: npm i @innei/pretty-logger-nestjs
 ```
 
-Requires `@nestjs/common` >= 10 (peer dependency).
+Requires `@nestjs/common` ^12 (NestJS 12 only).
 
 ## Usage (NestJS)
 
@@ -83,6 +83,8 @@ async function bootstrap() {
 }
 bootstrap()
 ```
+
+Structured params (Nest 12 default): `logger.log('User created', { userId: 1 })` attaches the object as metadata of that entry. Set `structuredParams: false` on the logger options to keep objects as extra message arguments. `logLevels` are honored. This package is the pretty TTY/file path — it does not implement Nest `json` / `flattenParams`.
 
 > [!WARNING]
 > After `wrapAll()`, avoid using `console.log` (or other wrapped stdio) inside `onData` to prevent feedback loops.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,11 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     globals: true,
-    include: ['src/__tests__/**/*.(spec|test).ts'],
+    include: [
+      'src/__tests__/**/*.(spec|test).ts',
+      'packages/**/*.(spec|test).ts',
+    ],
+    exclude: ['demo/**', '**/node_modules/**', '**/dist/**'],
   },
   plugins: [tsPath()],
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Upgrade `@innei/pretty-logger-nestjs` to **1.0.0** for NestJS 12 structured logging. Scope is the nest package only.

## What changed

- Peer `@nestjs/common` is now `^12` (Nest 10/11 dropped). Nest 12 is also a nest-package / workspace devDependency for types and tests.
- Deleted the PascalCase `isContextString` heuristic. `log` / `info` / `warn` / `debug` / `verbose` / `fatal` call `isLevelEnabled` then Nest 12’s `getContextAndMessagesToPrint`. `error` uses `getContextAndStackAndMessagesToPrint`.
- One consola call per log: `[prefix, ...messages, params?, stack?, timestampDiff]`. Nest `log` still maps to consola `info`; `info()` remains an alias of `log`.
- `params` (when present) is a **single extra consola argument** (the merged plain object). Not stringified here; not a new core `LogObject` field. Reporters and `onData` keep reading consola `args`.
- `structuredParams: false` is honored by the parent splitter (objects stay as extra message args).
- Constructor stays `super(context || '', options || {})`. Nest 12 does not assign `structuredParams` in the constructor; the splitter treats `!== false` as on, so `{}` keeps the default.
- Timestamp `+Nms` prefix and cluster worker prefix are unchanged.
- README / changelog document breakings: any trailing string is context; extra plain objects merge; `logLevels` now apply (previously-unfiltered `debug` / `verbose` may disappear).

## CI

- Node.js CI was auto-failing on deprecated Actions. `.github/workflows/build.yml` now uses `actions/checkout@v4`, `actions/setup-node@v4`, and `actions/cache@v4`.
- pnpm 11 then failed install with `ERR_PNPM_IGNORED_BUILDS`. `pnpm-workspace.yaml` now has `allowBuilds` (pnpm 11’s replacement for `onlyBuiltDependencies`; `package.json#pnpm` is ignored in v11): `@swc/core`, `esbuild`, and `unrs-resolver` allowed; `@nestjs/core` denied (its script is only `opencollective`, not a native build). Workflow still pins pnpm 11.0.0.

## Tests

Vitest in `packages/nest/logger.service.spec.ts` (consola instance mocked via `Logger.setLoggerInstance`):

- `log('msg', { userId: 1 }, 'UserService')` → context `UserService`, params `{ userId: 1 }`, one consola call
- `log('msg', { a: 1 }, { b: 2 })` → merged `{ a: 1, b: 2 }`
- `structuredParams: false` → objects stay as extra message args
- trailing non-PascalCase string is still context
- `error` with stack + context
- `logLevels: ['error']` suppresses `log()` / `warn()`

## Intentionally skipped

- **No core `params` field** on `LogObject` / FancyReporter / FileReporter. Params stay in consola `args`.
- **No Nest `json` / `flattenParams` ConsoleLogger JSON mode.** This logger remains the pretty TTY/file path.
- **No `@innei/pretty-logger-core` version bump** and no mx-space consumer bump.

## Verify constructor default

Nest 12 `ConsoleLogger` constructor sets `logLevels`, `colors`, and `prefix` only. `structuredParams` is documented default `true` and implemented as `this.options.structuredParams === false` in the splitter, so `super(..., {})` does not need an explicit `structuredParams: true`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6055bee8-cdbc-4176-89ff-d55bf922037f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6055bee8-cdbc-4176-89ff-d55bf922037f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

